### PR TITLE
Fixed NULL handling problem for timestamps, backport HIVE-4122

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -16,7 +16,7 @@
 
 Name=Hive
 name=hive
-version=0.9.0-csd-7
+version=0.9.0-csd-8
 year=2013
 
 javac.debug=on

--- a/ql/src/test/queries/clientpositive/timestamp_null.q
+++ b/ql/src/test/queries/clientpositive/timestamp_null.q
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS timestamp_null;
+CREATE TABLE timestamp_null (t1 TIMESTAMP);
+LOAD DATA LOCAL INPATH '../data/files/test.dat' OVERWRITE INTO TABLE timestamp_null;
+
+SELECT * FROM timestamp_null LIMIT 1;
+
+SELECT t1 FROM timestamp_null LIMIT 1;

--- a/ql/src/test/results/clientpositive/timestamp_null.q.out
+++ b/ql/src/test/results/clientpositive/timestamp_null.q.out
@@ -1,0 +1,33 @@
+PREHOOK: query: DROP TABLE IF EXISTS timestamp_null
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS timestamp_null
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE TABLE timestamp_null (t1 TIMESTAMP)
+PREHOOK: type: CREATETABLE
+POSTHOOK: query: CREATE TABLE timestamp_null (t1 TIMESTAMP)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: default@timestamp_null
+PREHOOK: query: LOAD DATA LOCAL INPATH '../data/files/test.dat' OVERWRITE INTO TABLE timestamp_null
+PREHOOK: type: LOAD
+PREHOOK: Output: default@timestamp_null
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../data/files/test.dat' OVERWRITE INTO TABLE timestamp_null
+POSTHOOK: type: LOAD
+POSTHOOK: Output: default@timestamp_null
+PREHOOK: query: SELECT * FROM timestamp_null LIMIT 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@timestamp_null
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM timestamp_null LIMIT 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@timestamp_null
+#### A masked pattern was here ####
+NULL
+PREHOOK: query: SELECT t1 FROM timestamp_null LIMIT 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@timestamp_null
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT t1 FROM timestamp_null LIMIT 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@timestamp_null
+#### A masked pattern was here ####
+NULL

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyTimestamp.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyTimestamp.java
@@ -66,12 +66,18 @@ public class LazyTimestamp extends LazyPrimitive<LazyTimestampObjectInspector, T
       s = "";
     }
 
-    Timestamp t;
+    Timestamp t = null;
     if (s.compareTo("NULL") == 0) {
-      t = null;
+      isNull = true;
       logExceptionMessage(bytes, start, length, "TIMESTAMP");
     } else {
-      t = Timestamp.valueOf(s);
+      try {
+        t = Timestamp.valueOf(s);
+        isNull = false;
+      } catch (IllegalArgumentException e) {
+        isNull = true;
+        logExceptionMessage(bytes, start, length, "TIMESTAMP");
+      }
     }
     data.set(t);
   }


### PR DESCRIPTION
Fixed problem with NULL handling load files and in database tables.
