### PR TITLE
Patch to fix SimpleDateFormat concurrency issue

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -16,7 +16,7 @@
 
 Name=Hive
 name=hive
-version=0.9.0-csd-8
+version=0.9.0-csd-9
 year=2013
 
 javac.debug=on

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
@@ -61,8 +61,13 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
   private static final int NO_DECIMAL_MASK = 0x7FFFFFFF;
   private static final int HAS_DECIMAL_MASK = 0x80000000;
 
-  private static final DateFormat dateFormat =
-    new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+  private static final ThreadLocal<DateFormat> threadLocalDateFormat =
+      new ThreadLocal<DateFormat>() {
+        @Override
+        protected synchronized DateFormat initialValue() {
+          return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        }
+      };
 
   private Timestamp timestamp = new Timestamp(0);
 
@@ -324,13 +329,13 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
     if (timestampString.length() > 19) {
       if (timestampString.length() == 21) {
         if (timestampString.substring(19).compareTo(".0") == 0) {
-          return dateFormat.format(timestamp);
+          return threadLocalDateFormat.get().format(timestamp);
         }
       }
-      return dateFormat.format(timestamp) + timestampString.substring(19);
+      return threadLocalDateFormat.get().format(timestamp) + timestampString.substring(19);
     }
 
-    return dateFormat.format(timestamp);
+    return threadLocalDateFormat.get().format(timestamp);
   }
 
   @Override


### PR DESCRIPTION
Make TimestampWritable SimpleDateFormat static into a ThreadLocal<DateFormat> since SimpleDateFormat is not thread-safe.  Fixes Timestamp corruption problem.
