### PR TITLE
Shark 0.9 csd 9

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -16,7 +16,7 @@
 
 Name=Hive
 name=hive
-version=0.9.0-csd-9
+version=0.9.0-csd-9.1
 year=2013
 
 javac.debug=on

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
@@ -106,7 +106,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
   }
 
   public void set(byte[] bytes, int offset) {
-    System.arraycopy(bytes, 0, internalBytes, offset, Math.min(MAX_BYTES, bytes.length - offset));
+    System.arraycopy(bytes, offset, internalBytes, 0, Math.min(MAX_BYTES, bytes.length - offset));
     bytesEmpty = false;
     clearTimestamp();
   }
@@ -119,7 +119,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
     }
     bytesEmpty = true;
     timestampEmpty = false;
-    timestamp = ts;
+    timestamp.setTime(ts.getTime());
   }
 
   public void set(TimestampWritable t) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
@@ -183,7 +183,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
     if (timestampEmpty) {
       populateTimestamp();
     }
-    return (Timestamp)timestamp.clone();
+    return timestamp;
   }
 
   /**


### PR DESCRIPTION
Make TimestampWritable "own" its internal state, stop adopting external memory references.
