### PR TITLE
Make timestamp own its state

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java
@@ -77,7 +77,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
         }
       };
 
-  private Timestamp timestamp = new Timestamp(0);
+  private final Timestamp timestamp = new Timestamp(0);
 
   /**
    * true if data is stored in timestamp field rather than byte arrays.
@@ -88,16 +88,11 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
   private boolean timestampEmpty;
 
   /* Allow use of external byte[] for efficiency */
-  private byte[] currentBytes;
   private final byte[] internalBytes = new byte[MAX_BYTES];
-  private byte[] externalBytes;
-  private int offset;
 
   /* Constructors */
   public TimestampWritable() {
     bytesEmpty = false;
-    currentBytes = internalBytes;
-    offset = 0;
 
     clearTimestamp();
   }
@@ -115,23 +110,22 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
   }
 
   public void set(byte[] bytes, int offset) {
-    externalBytes = bytes;
-    this.offset = offset;
+    System.arraycopy(bytes, offset, internalBytes, 0, Math.min(MAX_BYTES, bytes.length - offset));
     bytesEmpty = false;
-    currentBytes = externalBytes;
 
     clearTimestamp();
   }
 
-  public void set(Timestamp t) {
-    if (t == null) {
+  public void set(Timestamp ts) {
+    if (ts == null) {
       timestamp.setTime(0);
       timestamp.setNanos(0);
       return;
     }
-    this.timestamp = t;
     bytesEmpty = true;
     timestampEmpty = false;
+    timestamp.setTime(ts.getTime());
+    timestamp.setNanos(ts.getNanos());
   }
 
   public void set(TimestampWritable t) {
@@ -139,11 +133,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
       set(t.getTimestamp());
       return;
     }
-    if (t.currentBytes == t.externalBytes) {
-      set(t.currentBytes, t.offset);
-    } else {
-      set(t.currentBytes, 0);
-    }
+    set(t.internalBytes, 0);
   }
 
   private void clearTimestamp() {
@@ -152,7 +142,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
 
   public void writeToByteStream(Output byteStream) {
     checkBytes();
-    byteStream.write(currentBytes, offset, getTotalLength());
+    byteStream.write(internalBytes, 0, getTotalLength());
   }
 
   /**
@@ -163,7 +153,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
     if (!timestampEmpty) {
       return millisToSeconds(timestamp.getTime());
     } else if (!bytesEmpty) {
-      return TimestampWritable.getSeconds(currentBytes, offset);
+      return TimestampWritable.getSeconds(internalBytes, 0);
     } else {
       throw new IllegalStateException("Both timestamp and bytes are empty");
     }
@@ -178,7 +168,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
       return timestamp.getNanos();
     } else if (!bytesEmpty) {
       return hasDecimalOrSecondVInt() ?
-          TimestampWritable.getNanos(currentBytes, offset + 4) : 0;
+          TimestampWritable.getNanos(internalBytes, 4) : 0;
     } else {
       throw new IllegalStateException("Both timestamp and bytes are empty");
     }
@@ -190,7 +180,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
    */
   int getTotalLength() {
     checkBytes();
-    return getTotalLength(currentBytes, offset);
+    return getTotalLength(internalBytes, 0);
   }
 
   public static int getTotalLength(byte[] bytes, int offset) {
@@ -222,7 +212,7 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
     int len = getTotalLength();
     byte[] b = new byte[len];
 
-    System.arraycopy(currentBytes, offset, b, 0, len);
+    System.arraycopy(internalBytes, 0, b, 0, len);
     return b;
   }
 
@@ -266,9 +256,6 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
           4 + WritableUtils.decodeVIntSize(internalBytes[4]),
           seconds >> 31);
     }
-
-    currentBytes = internalBytes;
-    this.offset = 0;
   }
 
   /**
@@ -280,8 +267,6 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
     if (bytesEmpty) {
       // Populate byte[] from Timestamp
       convertTimestampToBytes(timestamp, internalBytes, 0);
-      offset = 0;
-      currentBytes = internalBytes;
       bytesEmpty = false;
     }
   }
@@ -332,13 +317,11 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
         }
       }
     }
-    currentBytes = internalBytes;
-    this.offset = 0;
   }
 
   public void write(OutputStream out) throws IOException {
     checkBytes();
-    out.write(currentBytes, offset, getTotalLength());
+    out.write(internalBytes, 0, getTotalLength());
   }
 
   public void write(DataOutput out) throws IOException {
@@ -586,11 +569,11 @@ public class TimestampWritable implements WritableComparable<TimestampWritable> 
   }
 
   private final boolean hasDecimalOrSecondVInt() {
-    return hasDecimalOrSecondVInt(currentBytes[offset]);
+    return hasDecimalOrSecondVInt(internalBytes[0]);
   }
 
   public final boolean hasDecimal() {
-    return hasDecimalOrSecondVInt() || currentBytes[offset + 4] != -1;
+    return hasDecimalOrSecondVInt() || internalBytes[4] != -1;
     // If the first byte of the VInt is -1, the VInt itself is -1, indicating that there is a
     // second VInt but the nanoseconds field is actually 0.
   }


### PR DESCRIPTION
@jhartlaub

A version of https://github.com/clearstorydata/hive/pull/6 on top of the extended version of TimestampWritable supporting years before 1970 and after 2038.
