### PR TITLE
REL-367 Update csd nexus deploy

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -553,6 +553,11 @@
     <replace file="${build.dir}/pom.xml">
       <replacetoken>&lt;dependencies&gt;</replacetoken>
       <replacevalue>
+        &lt;parent&gt;
+        &lt;groupId&gt;com.clearstorydata&lt;/groupId&gt;
+        &lt;artifactId&gt;clearstorydata-parent&lt;/artifactId&gt;
+        &lt;version&gt;2.0.7&lt;/version&gt;
+        &lt;/parent&gt;
         &lt;name&gt;Apache Hive 0.12&lt;/name&gt;
         &lt;description&gt;Hive is a data warehouse infrastructure built on top of Hadoop see
         http://wiki.apache.org/hadoop/Hive &lt;/description&gt;

--- a/build.xml
+++ b/build.xml
@@ -1304,48 +1304,15 @@
         </artifact:deploy>
       </then>
       <elseif>
-        <equals arg1="${mvn.publish.repo}" arg2="csd_release" />
+        <equals arg1="${mvn.publish.repo}" arg2="csd" />
         <then>
           <artifact:deploy
               file="${mvn.jar.dir}/hive-${hive.project}-${version}.jar">
             <pom refid="hive.project.pom" />
-            <remoteRepository
-                id="${mvn.csd.repo.id}" url="${mvn.csd_releases.repo.url}"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}.jar.asc"
-                    type="jar.asc"/>
-            <attach file="${mvn.pom.dir}/hive-${hive.project}-${version}.pom.asc"
-                    type="pom.asc"/>
             <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-sources.jar"
                     type="jar" classifier="sources"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-sources.jar.asc"
-                    type="jar.asc" classifier="sources"/>
             <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-javadoc.jar"
                     type="jar" classifier="javadoc"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-javadoc.jar.asc"
-                    type="jar.asc" classifier="javadoc"/>
-          </artifact:deploy>
-        </then>
-      </elseif>
-      <elseif>
-        <equals arg1="${mvn.publish.repo}" arg2="csd_snapshot" />
-        <then>
-          <artifact:deploy
-              file="${mvn.jar.dir}/hive-${hive.project}-${version}.jar">
-            <pom refid="hive.project.pom" />
-            <remoteRepository
-                id="${mvn.csd.repo.id}" url="${mvn.csd_snapshots.repo.url}"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}.jar.asc"
-                    type="jar.asc"/>
-            <attach file="${mvn.pom.dir}/hive-${hive.project}-${version}.pom.asc"
-                    type="pom.asc"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-sources.jar"
-                    type="jar" classifier="sources"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-sources.jar.asc"
-                    type="jar.asc" classifier="sources"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-javadoc.jar"
-                    type="jar" classifier="javadoc"/>
-            <attach file="${mvn.jar.dir}/hive-${hive.project}-${version}-javadoc.jar.asc"
-                    type="jar.asc" classifier="javadoc"/>
           </artifact:deploy>
         </then>
       </elseif>


### PR DESCRIPTION
Not only simpler, but it now also works, which is always a good thing.

In addition to these changes, users will require a settings file in $HOME/.ant/settings.xml (can't use our usual ~/.m2/settings.xml, which will be read if ~/.ant/settings.xml is not present.)  The new settings.xml just needs to contain:

```
<settings>
  <servers>
    <server>
      <id>nexus</id>
      <username>???</username>
      <password>???</password>
    </server>
  </servers>
</settings>
```

...with appropriate values for `username` and `password`.

After that, building and deploying to nexus is just a matter of:

```
ant maven-build
ant maven-publish -Dmvn.publish.repo=csd
```
