### PR TITLE
Use some Hive pom files from the published 0.13.1a artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ hcatalog/core/target
 hcatalog/webhcat/java-client/target
 hcatalog/storage-handlers/hbase/target
 hcatalog/webhcat/svr/target
+dependency-reduced-pom.xml

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -148,36 +148,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
-              <artifactSet>
-                <includes>
-                  <include>jline:jline</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>jline</pattern>
-                  <shadedPattern>org.spark_project.jline</shadedPattern>
-                  <includes>
-                    <include>jline.**</include>
-                    <include>org.fusesource.**</include>
-                  </includes>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -157,38 +157,6 @@
   <build>
     <sourceDirectory>${basedir}/src/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>
-    <plugins>
-     <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
-              <artifactSet>
-                <includes>
-                  <include>jline:jline</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>jline</pattern>
-                  <shadedPattern>org.spark_project.jline</shadedPattern>
-                  <includes>
-                    <include>jline.**</include>
-                    <include>org.fusesource.**</include>
-                  </includes>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/storage-handlers/hbase/pom.xml
+++ b/hcatalog/storage-handlers/hbase/pom.xml
@@ -25,7 +25,7 @@
   <parent>
   <groupId>org.spark-project.hive.hcatalog</groupId>
   <artifactId>hive-hcatalog</artifactId>
-  <version>0.13.1a</version>
+  <version>0.13.1a-csd-1</version>
   <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/streaming/pom.xml
+++ b/hcatalog/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hwi/pom.xml
+++ b/hwi/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-serde/pom.xml
+++ b/itests/custom-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/test-serde/pom.xml
+++ b/itests/test-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/odbc/pom.xml
+++ b/odbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.spark-project.hive</groupId>
   <artifactId>hive</artifactId>
-  <version>0.13.1a</version>
+  <version>0.13.1a-csd-1</version>
   <packaging>pom</packaging>
   <distributionManagement>
     <snapshotRepository>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.20/pom.xml
+++ b/shims/0.20/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.20S/pom.xml
+++ b/shims/0.20S/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common-secure/pom.xml
+++ b/shims/common-secure/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>0.13.1a</version>
+    <version>0.13.1a-csd-1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
This makes Spark compile with this version of Hive again without the jline error.

@markhamstra 
