### PR TITLE
SPY-967: Create a faster histogram algorithm for the percentileApprox function

### DIFF
--- a/accumulo-handler/pom.xml
+++ b/accumulo-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/streaming/pom.xml
+++ b/hcatalog/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.spark-project.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hwi/pom.xml
+++ b/hwi/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/odbc/pom.xml
+++ b/odbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.spark-project.hive</groupId>
   <artifactId>hive</artifactId>
-  <version>1.2.1.spark-csd-2</version>
+  <version>1.2.1.spark-csd-3</version>
   <packaging>pom</packaging>
 
   <!-- See http://central.sonatype.org/pages/apache-maven.html -->

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/FastNumericHistogram.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/FastNumericHistogram.java
@@ -1,0 +1,343 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.udf.generic;
+
+import java.util.*;
+
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+
+
+/**
+ * A generic, re-usable histogram class that supports partial aggregations.
+ * The algorithm is a heuristic adapted from the following paper:
+ * Yael Ben-Haim and Elad Tom-Tov, "A streaming parallel decision tree algorithm",
+ * J. Machine Learning Research 11 (2010), pp. 849--872. Although there are no approximation
+ * guarantees, it appears to work well with adequate data and a large (e.g., 20-80) number
+ * of histogram bins.
+ */
+public class FastNumericHistogram {
+  /**
+   * The Coord class defines a histogram bin, which is just an (x,y) pair.
+   */
+  static class Coord implements Comparable {
+    double x;
+    double y;
+
+    public int compareTo(Object other) {
+      return Double.compare(x, ((Coord) other).x);
+    }
+  };
+
+  // Class variables
+  private int nbins;
+  private int maxBins;
+  private int nusedbins;
+  private ArrayList<Coord> bins;
+  private Random prng;
+
+  /**
+   * Creates a new histogram object. Note that the allocate() or merge()
+   * method must be called before the histogram can be used.
+   */
+  public FastNumericHistogram() {
+    nbins = 0;
+    nusedbins = 0;
+    maxBins = 0;
+    bins = null;
+
+    // init the RNG for breaking ties in histogram merging. A fixed seed is specified here
+    // to aid testing, but can be eliminated to use a time-based seed (which would
+    // make the algorithm non-deterministic).
+    prng = new Random(31183);
+  }
+
+  /**
+   * Resets a histogram object to its initial state. allocate() or merge() must be
+   * called again before use.
+   */
+  public void reset() {
+    bins = null;
+    nbins = maxBins = nusedbins = 0;
+  }
+
+  /**
+   * Returns the number of bins currently being used by the histogram.
+   */
+  public int getUsedBins() {
+    return nusedbins;
+  }
+
+  /**
+   * Returns true if this histogram object has been initialized by calling merge()
+   * or allocate().
+   */
+  public boolean isReady() {
+    return nbins != 0;
+  }
+
+  /**
+   * Returns a particular histogram bin.
+   */
+  public Coord getBin(int b) {
+    return bins.get(b);
+  }
+
+  /**
+   * Sets the number of histogram bins to use for approximating data.
+   *
+   * @param num_bins Number of non-uniform-width histogram bins to use
+   */
+  public void allocate(int num_bins) {
+    nbins = num_bins;
+    maxBins = nbins * 2;
+    bins = new ArrayList<>();
+    nusedbins = 0;
+  }
+
+  /**
+   * Takes a serialized histogram created by the serialize() method and merges
+   * it with the current histogram object.
+   *
+   * @param other A serialized histogram created by the serialize() method
+   * @see #merge
+   */
+  public void merge(List other, DoubleObjectInspector doi) {
+    if(other == null) {
+      return;
+    }
+
+    if(nbins == 0 || nusedbins == 0)  {
+      // Our aggregation buffer has nothing in it, so just copy over 'other'
+      // by deserializing the ArrayList of (x,y) pairs into an array of Coord objects
+      nbins = (int) doi.get(other.get(0));
+      nusedbins = (other.size()-1)/2;
+      bins = new ArrayList<Coord>(nusedbins);
+      for (int i = 1; i < other.size(); i+=2) {
+        Coord bin = new Coord();
+        bin.x = doi.get(other.get(i));
+        bin.y = doi.get(other.get(i+1));
+        bins.add(bin);
+      }
+    } else {
+      // The aggregation buffer already contains a partial histogram. Therefore, we need
+      // to merge histograms using Algorithm #2 from the Ben-Haim and Tom-Tov paper.
+
+      ArrayList<Coord> tmp_bins = new ArrayList<Coord>(nusedbins + (other.size()-1)/2);
+      // Copy all the histogram bins from us and 'other' into an overstuffed histogram
+      for (int i = 0; i < nusedbins; i++) {
+        Coord bin = new Coord();
+        bin.x = bins.get(i).x;
+        bin.y = bins.get(i).y;
+        tmp_bins.add(bin);
+      }
+      for (int j = 1; j < other.size(); j += 2) {
+        Coord bin = new Coord();
+        bin.x = doi.get(other.get(j));
+        bin.y = doi.get(other.get(j+1));
+        tmp_bins.add(bin);
+      }
+      Collections.sort(tmp_bins);
+
+      // Now trim the overstuffed histogram down to the correct number of bins
+      bins = tmp_bins;
+      nusedbins += (other.size()-1)/2;
+      trim();
+    }
+  }
+
+
+  /**
+   * Adds a new data point to the histogram approximation. Make sure you have
+   * called either allocate() or merge() first. This method implements Algorithm #1
+   * from Ben-Haim and Tom-Tov, "A Streaming Parallel Decision Tree Algorithm", JMLR 2010.
+   *
+   * @param v The data point to add to the histogram approximation.
+   */
+  public void add(double v) {
+    // Binary search to find the closest bucket that v should go into.
+    // 'bin' should be interpreted as the bin to shift right in order to accomodate
+    // v. As a result, bin is in the range [0,N], where N means that the value v is
+    // greater than all the N bins currently in the histogram. It is also possible that
+    // a bucket centered at 'v' already exists, so this must be checked in the next step.
+    int bin = 0;
+    for(int l=0, r=nusedbins; l < r; ) {
+      bin = (l+r)/2;
+      if(bins.get(bin).x > v) {
+        r = bin;
+      } else {
+        if(bins.get(bin).x < v) {
+          l = ++bin;
+        } else {
+          break; // break loop on equal comparator
+        }
+      }
+    }
+
+    // If we found an exact bin match for value v, then just increment that bin's count.
+    // Otherwise, we need to insert a new bin and trim the resulting histogram back to size.
+    // A possible optimization here might be to set some threshold under which 'v' is just
+    // assumed to be equal to the closest bin -- if fabs(v-bins[bin].x) < THRESHOLD, then
+    // just increment 'bin'. This is not done now because we don't want to make any
+    // assumptions about the range of numeric data being analyzed.
+    if(bin < nusedbins && bins.get(bin).x == v) {
+      bins.get(bin).y++;
+    } else {
+      Coord newBin = new Coord();
+      newBin.x = v;
+      newBin.y = 1;
+      bins.add(bin, newBin);
+
+      // Trim the bins down to the correct number of bins.
+      if(++nusedbins > maxBins) {
+        trim();
+      }
+    }
+  }
+
+  /**
+   * Trims a histogram down to 'nbins' bins by iteratively merging the closest bins.
+   * If two pairs of bins are equally close to each other, decide uniformly at random which
+   * pair to merge, based on a PRNG.
+   * The algorithm doesn't guarantee a full trim, but does guarantee we get smaller.
+   */
+  private void trim() {
+    // sort the diffs
+    double diffs[] = new double[nusedbins - 1];
+    for (int i = 0; i < nusedbins - 1; i++) {
+      diffs[i] = bins.get(i + 1).x - bins.get(i).x;
+    }
+    Arrays.sort(diffs);
+
+    // We want to have nbins bins, so we want to keep the largest nbins-1 diffs
+    double maxDiscardDiff = diffs[nusedbins - nbins];
+
+    // If there are a lot of diffs == maxDiscardDiff, make sure we get rid of at
+    // least one of them!  We delete others at ~50% probability.  We could count
+    // the number of matching diffs and do a better job here, but :shrug:
+    boolean deletedMaxDiscard = false;
+    ArrayList<Coord> newBins = new ArrayList<>(nusedbins);
+
+    Coord lastValid = bins.get(0);
+    newBins.add(lastValid);
+    for (int i = 1; i < nusedbins; i++) {
+      Coord other = bins.get(i);
+      double diff = other.x - lastValid.x;
+      if (diff < maxDiscardDiff) {
+        mergeBins(lastValid, other);
+      } else if (diff == maxDiscardDiff && (!deletedMaxDiscard || prng.nextBoolean())) {
+        mergeBins(lastValid, other);
+        deletedMaxDiscard = true;
+      } else {
+        newBins.add(other);
+        lastValid = other;
+      }
+    }
+    bins = newBins;
+    nusedbins = newBins.size();
+  }
+
+  private void mergeBins(Coord dest, Coord other) {
+    // Merge the two bins into their average x location, weighted by their heights.
+    // The height of the new bin is the sum of the heights of the old bins.
+    double d = dest.y + other.y;
+    dest.x = dest.x * dest.y / d;
+    dest.x += other.x * other.y / d;
+    dest.y = d;
+  }
+
+  /**
+   * Gets an approximate quantile value from the current histogram. Some popular
+   * quantiles are 0.5 (median), 0.95, and 0.98.
+   *
+   * @param q The requested quantile, must be strictly within the range (0,1).
+   * @return The quantile value.
+   */
+  public double quantile(double q) {
+    // The algorithm here is similar to that in UDAFPercentile.getPercentile.
+    assert(bins != null && nusedbins > 0 && nbins > 0);
+    double sum = 0;
+
+    for (int b = 0; b < nusedbins; b++)  {
+      sum += bins.get(b).y;
+    }
+    long n = Math.round(sum) - 1;
+    double position = q * n;
+
+    long lower = (long)Math.floor(position);
+    long higher = (long)Math.ceil(position);
+
+    // Linear search since this won't take much time from the total execution anyway
+    // lower has the range of [0 .. total-1]
+    // The first entry with accumulated count (lower+1) corresponds to the lower position.
+    int i = 0;
+    long csum = 0;
+    while (i < nusedbins && (csum += Math.round(bins.get(i).y)) < lower + 1) {
+      i++;
+    }
+
+    double lowerKey = bins.get(i).x;
+    if (higher == lower) {
+      // no interpolation needed because position does not have a fraction
+      return lowerKey;
+    }
+
+    if (i < nusedbins && csum < higher + 1) {
+      i++;
+    }
+
+    double higherKey = bins.get(i).x;
+
+    if (higherKey == lowerKey) {
+      // no interpolation needed because lower position and higher position has the same key
+      return lowerKey;
+    }
+
+    // Linear interpolation to get the exact percentile
+    return (higher - position) * lowerKey + (position - lower) * higherKey;
+  }
+
+  /**
+   * In preparation for a Hive merge() call, serializes the current histogram object into an
+   * ArrayList of DoubleWritable objects. This list is deserialized and merged by the
+   * merge method.
+   *
+   * @return An ArrayList of Hadoop DoubleWritable objects that represents the current
+   * histogram.
+   * @see #merge
+   */
+  public ArrayList<DoubleWritable> serialize() {
+    ArrayList<DoubleWritable> result = new ArrayList<DoubleWritable>();
+
+    // Return a single ArrayList where the first element is the number of bins bins,
+    // and subsequent elements represent bins (x,y) pairs.
+    result.add(new DoubleWritable(nbins));
+    if(bins != null) {
+      for(int i = 0; i < nusedbins; i++) {
+        result.add(new DoubleWritable(bins.get(i).x));
+        result.add(new DoubleWritable(bins.get(i).y));
+      }
+    }
+
+    return result;
+  }
+
+  public int getNumBins() {
+    return bins == null ? 0 : bins.size();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFPercentileApprox.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFPercentileApprox.java
@@ -353,7 +353,7 @@ public class GenericUDAFPercentileApprox extends AbstractGenericUDAFResolver {
     // inside our own, so that we can also store requested quantile values between calls
     @AggregationType(estimable = true)
     static class PercentileAggBuf extends AbstractAggregationBuffer {
-      NumericHistogram histogram;   // histogram used for quantile approximation
+      FastNumericHistogram histogram;   // histogram used for quantile approximation
       double[] quantiles;           // the quantiles requested
       @Override
       public int estimate() {
@@ -366,7 +366,7 @@ public class GenericUDAFPercentileApprox extends AbstractGenericUDAFResolver {
     @Override
     public AggregationBuffer getNewAggregationBuffer() throws HiveException {
       PercentileAggBuf result = new PercentileAggBuf();
-      result.histogram = new NumericHistogram();
+      result.histogram = new FastNumericHistogram();
       reset(result);
       return result;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/JavaDataModel.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/JavaDataModel.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.util;
 
+import org.apache.hadoop.hive.ql.udf.generic.FastNumericHistogram;
 import org.apache.hadoop.hive.ql.udf.generic.NumDistinctValueEstimator;
 import org.apache.hadoop.hive.ql.udf.generic.NumericHistogram;
 
@@ -161,6 +162,18 @@ public enum JavaDataModel {
   }
 
   public int lengthFor(NumericHistogram histogram) {
+    int length = object();
+    length += primitive1() * 2;       // two int
+    int numBins = histogram.getNumBins();
+    if (numBins > 0) {
+      length += arrayList();   // List<Coord>
+      length += numBins * (object() + primitive2() * 2); // Coord holds two doubles
+    }
+    length += lengthForRandom();      // Random
+    return length;
+  }
+
+  public int lengthFor(FastNumericHistogram histogram) {
     int length = object();
     length += primitive1() * 2;       // two int
     int numBins = histogram.getNumBins();

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestFastNumericHistogram.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestFastNumericHistogram.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.udf.generic;
+
+import junit.framework.TestCase;
+
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * This is copied from TestNumericHistogram, but it's frankly inadequate.  There was no attempt
+ * to use any of the code that's actually implemented in NumericHistogram.  But that's okay,
+ * because the tests were not being run anyway.  So I implemented testHistogramSimilarity() to
+ * verify *closeness* to NumericHistogram.
+ */
+public class TestFastNumericHistogram extends TestCase {
+
+  private void assertApproxEquals(double expected, double actual) {
+    assertTrue(
+        "Values are too far: expected=" + expected + ", actual=" + actual,
+        Math.abs(expected - actual) < 1e-7);
+  }
+
+  public void testInterpolation() {
+    FastNumericHistogram h = new FastNumericHistogram();
+    h.allocate(100);
+    h.add(10.0);
+    h.add(10.0);
+    h.add(20.0);
+    h.add(20.0);
+    h.add(20.0);
+    h.add(40.0);
+    h.add(40.0);
+    h.add(40.0);
+    h.add(50.0);
+    h.add(50.0);
+    assertApproxEquals(10.0, h.quantile(1 / 18.0));
+    assertApproxEquals(10.0, h.quantile(2 / 18.0));
+    assertApproxEquals(15.0, h.quantile(3 / 18.0));
+    assertApproxEquals(20.0, h.quantile(4 / 18.0));
+    assertApproxEquals(20.0, h.quantile(5 / 18.0));
+    assertApproxEquals(20.0, h.quantile(6 / 18.0));
+    assertApproxEquals(20.0, h.quantile(7 / 18.0));
+    assertApproxEquals(20.0, h.quantile(8 / 18.0));
+    assertApproxEquals(30.0, h.quantile(9 / 18.0));
+    assertApproxEquals(40.0, h.quantile(10 / 18.0));
+    assertApproxEquals(40.0, h.quantile(11 / 18.0));
+    assertApproxEquals(40.0, h.quantile(12 / 18.0));
+    assertApproxEquals(40.0, h.quantile(13 / 18.0));
+    assertApproxEquals(40.0, h.quantile(14 / 18.0));
+    assertApproxEquals(45.0, h.quantile(15 / 18.0));
+    assertApproxEquals(50.0, h.quantile(16 / 18.0));
+    assertApproxEquals(50.0, h.quantile(17 / 18.0));
+  }
+
+  public void testHistogramSimilarity() {
+    int numToCheck = 50;
+    int MAX_SIZE_TO_VERIFY = 100000000;
+    Random rand = new Random(System.nanoTime());
+    boolean passed = true;
+    while (passed && numToCheck < MAX_SIZE_TO_VERIFY) {
+      numToCheck = numToCheck * 2;
+      NumericHistogram nh = new NumericHistogram();
+      nh.allocate(100);
+      FastNumericHistogram fnh = new FastNumericHistogram();
+      fnh.allocate(100);
+      double values[] = new double[numToCheck];
+      for (int i = 0; i < numToCheck; i++) {
+        values[i] = rand.nextDouble();
+      }
+      long startNH = System.nanoTime();
+      for (int i = 0; i < numToCheck; i++) {
+        nh.add(values[i]);
+      }
+      long totalNH = System.nanoTime() - startNH;
+      long startFNH = System.nanoTime();
+      for (int i = 0; i < numToCheck; i++) {
+        fnh.add(values[i]);
+      }
+      long totalFNH = System.nanoTime() - startFNH;
+      passed = true;
+      Arrays.sort(values);
+      System.out.println(
+        "Checking " + numToCheck + " Fast is faster by: " + totalNH / (double)totalFNH);
+
+      passed = verify(values, nh, fnh, .5) && passed;
+      passed = verify(values, nh, fnh, .25) && passed;
+      passed = verify(values, nh, fnh, .75) && passed;
+      passed = verify(values, nh, fnh, .98) && passed;
+      passed = verify(values, nh, fnh, .99) && passed;
+    }
+    assertTrue(passed);
+  }
+
+  public boolean verify(double[] values, NumericHistogram nh, FastNumericHistogram fnh, double quantile) {
+    double expected = values[(int)(values.length * quantile)];
+    double actual1 = nh.quantile(quantile);
+    double actual2 = fnh.quantile(quantile);
+
+    // There are 100 buckets in the histogram, so we should be within 1%.
+    if (Math.abs(actual1 - actual2) > 1e-2) {
+      System.out.println("For " + quantile + " Fast and Numeric were too far apart: " +
+        expected + " vs " + actual1 + " vs " + actual2);
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.20S/pom.xml
+++ b/shims/0.20S/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
   </parent>
 
   <groupId>org.spark-project.hive</groupId>
   <artifactId>spark-client</artifactId>
   <packaging>jar</packaging>
   <name>Spark Remote Client</name>
-  <version>1.2.1.spark-csd-2</version>
+  <version>1.2.1.spark-csd-3</version>
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.spark-project.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.1.spark-csd-2</version>
+    <version>1.2.1.spark-csd-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
The FastNumericHistogram rewrites the trim and add functions in NumericHistogram which winds up calling a fairly expensive linear process for each addition.  This version results in nearly identical values to NumericHistogram (as verified by the test I added), but is ~30 times faster in the percentile call where the number of bins used in the histogram is large.
It uses roughly twice the amount of memory, although I don't expect that to be too problematic.

I have a hive built using this code under java8 uploaded to maven, but we can rebuild with java7, if that seems reasonable to do.

For the acceptance test that I've been running (query_d59301180ab8609d4da5f950e81b67c8.json), the previously 7s sparkSQL query runs in under half a second, so the raw 30x seems to have translated through to sparky as well.  It also results in numerically more similar results.  The .25 percentile is the only unmatched value (for whatever reason), whereas the previous code disagreed on all of them.  I don't expect that matters much, but  :shrug:
